### PR TITLE
updated "Archway Unique ID (Object Identifier)" to "ArchwayUniqueID (Object Identifier - IE)"

### DIFF
--- a/rosetta-configs/new-rosetta-csv-mapping.cfg
+++ b/rosetta-configs/new-rosetta-csv-mapping.cfg
@@ -17,7 +17,7 @@ MD5=MD5_HASH
 
 Title=CAA Demo Ingest
 Title (DC)=UAT Trial
-Archway Unique ID (Object Identifier)=R12345679
+ArchwayUniqueID (Object Identifier - IE)=R12345679
 Identifier - Archway Unique Id (DC)=R12345679
 Revision Number=1
 Preservation Type=PRESERVATION_MASTER
@@ -44,6 +44,6 @@ pathmask=F:\CAA\
 [rosetta csv fields]  
 CSVSECTIONS=IE,REPRESENTATION,FILE
 
-IE = Title (DC),Access Rights Policy ID (IE),Archway Unique ID (Object Identifier),Identifier - Archway Unique Id (DC),Archway Series Number,Provenance (dcterms),IE Entity Type,Submission Reason
+IE = Title (DC),Access Rights Policy ID (IE),ArchwayUniqueID (Object Identifier - IE),Identifier - Archway Unique Id (DC),Archway Series Number,Provenance (dcterms),IE Entity Type,Submission Reason
 REPRESENTATION = Revision Number,Usage Type,Representation Code,Preservation Type,Digital Original
 FILE = File Original Path,File Original Name,File Label,MD5,File Modification Date (General File Characteristics),File Creation Date (General File Characteristics)

--- a/rosetta-csv-field-notes/rosetta-fields.txt
+++ b/rosetta-csv-field-notes/rosetta-fields.txt
@@ -2,7 +2,7 @@
 Title (DC)
 Title (DC)
 Access Rights Policy ID (IE)
-Archway Unique ID (Object Identifier)
+ArchwayUniqueID (Object Identifier - IE)
 Identifier - Archway Unique Id (DC)
 Archway Series Number
 Provenance (dcterms)
@@ -24,7 +24,7 @@ File Creation Date (General File Characteristics)
 "name": "SIP Title",
 "name": "Title (DC)",
 "name": "Access Rights Policy ID (IE)",
-"name": "Archway Unique ID (Object Identifier)",
+"name": "ArchwayUniqueID (Object Identifier - IE)",
 "name": "Identifier - Archway Unique Id (DC)",
 "name": "Archway Series Number",
 "name": "Provenance (dcterms)",

--- a/rosetta-schemas/rosetta-csv-validation-schema-anz.json
+++ b/rosetta-schemas/rosetta-csv-validation-schema-anz.json
@@ -39,7 +39,7 @@
             }
         },
         {
-            "name": "Archway Unique ID (Object Identifier)",
+            "name": "ArchwayUniqueID (Object Identifier - IE)",
             "description": "Record number in Archive New Zealand's catalogue.",
             "type": "http://www.w3.org/2001/XMLSchema#string",
             "constraints": {


### PR DESCRIPTION
so it fits what Rosetta expects in recent versions